### PR TITLE
App settings add writable settings, fix tests

### DIFF
--- a/test/unit/core/entities/app_settings/app_settings_initialize_test.dart
+++ b/test/unit/core/entities/app_settings/app_settings_initialize_test.dart
@@ -4,6 +4,7 @@ import 'package:hmi_core/src/core/json/json_map.dart';
 import 'package:hmi_core/src/core/log/log.dart';
 import 'package:hmi_core/src/core/result/result.dart';
 import 'package:hmi_core/src/core/error/failure.dart';
+import 'fake_text_file.dart';
 ///
 /// Fake implementation of [JsonMap] for tests
 class FakeJsonMap implements JsonMap<dynamic> {
@@ -116,6 +117,52 @@ void main() {
       expect(AppSettings.getSetting('test_overwrite_setting_1'), -123);
       expect(AppSettings.getSetting('test_overwrite_setting_2'), 0);
       expect(AppSettings.getSetting('test_overwrite_setting_3'), 27);
+    });
+    test('restore writable setting from store file', () async {
+      for (final map in validWritableMaps) {
+        final storeFile = FakeTextFile(
+          '{"test_writable_setting_1":"rewritten","test_writable_setting_2":"rewritten","test_writable_setting_3":"rewritten"}',
+        );
+        await AppSettings.initialize(
+          writable: FakeJsonMap(Ok(map)),
+          store: storeFile,
+        );
+        expect(AppSettings.getSetting('test_writable_setting_1'), "rewritten");
+        expect(AppSettings.getSetting('test_writable_setting_2'), "rewritten");
+        expect(AppSettings.getSetting('test_writable_setting_3'), "rewritten");
+      }
+    });
+    test('ignore read only settings in store file', () async {
+      for (final map in validReadOnlyMaps) {
+        final storeFile = FakeTextFile(
+          '{"test_setting_1":"rewritten","test_setting_2":"rewritten","test_setting_3":"rewritten"}',
+        );
+        await AppSettings.initialize(
+          readOnly: FakeJsonMap(Ok(map)),
+          store: storeFile,
+        );
+        expect(AppSettings.getSetting('test_setting_1'), map['test_setting_1']);
+        expect(AppSettings.getSetting('test_setting_2'), map['test_setting_2']);
+        expect(AppSettings.getSetting('test_setting_3'), map['test_setting_3']);
+      }
+    });
+    test('ignore not found settings in store file', () async {
+      final storeFile = FakeTextFile(
+        '{"test_not_found_setting_1":"rewritten","test_not_found_setting_2":"rewritten","test_not_found_setting_3":"rewritten"}',
+      );
+      await AppSettings.initialize(store: storeFile);
+      expect(
+        AppSettings.getSetting('test_not_found_setting_1', onError: ((err) => null)),
+        null,
+      );
+      expect(
+        AppSettings.getSetting('test_not_found_setting_2', onError: ((err) => null)),
+        null,
+      );
+      expect(
+        AppSettings.getSetting('test_not_found_setting_3', onError: ((err) => null)),
+        null,
+      );
     });
     test('getSetting onError passes new value case error', () async {
       final notFoundMaps = [

--- a/test/unit/core/entities/app_settings/app_settings_initialize_test.dart
+++ b/test/unit/core/entities/app_settings/app_settings_initialize_test.dart
@@ -1,49 +1,174 @@
 import 'package:flutter_test/flutter_test.dart';
-import 'package:hmi_core/hmi_core.dart';
-import 'fake_text_file.dart';
-import 'settings_data.dart';
+import 'package:hmi_core/hmi_core_app_settings.dart';
+import 'package:hmi_core/src/core/json/json_map.dart';
+import 'package:hmi_core/src/core/log/log.dart';
+import 'package:hmi_core/src/core/result/result.dart';
+import 'package:hmi_core/src/core/error/failure.dart';
+///
+/// Fake implementation of [JsonMap] for tests
+class FakeJsonMap implements JsonMap<dynamic> {
+  final ResultF<Map<String, dynamic>> _map;
+  ///
+  /// Creates [FakeJsonMap] with a given [map].
+  const FakeJsonMap(ResultF<Map<String, dynamic>> map) : _map = map;
+  //
+  @override
+  Future<ResultF<Map<String, dynamic>>> get decoded async {
+    return _map;
+  }
+}
+//
 void main() {
   Log.initialize();
-  group('AppUiSettings initialize', () {
-    test('sets data normally with valid json format and valid data', () async {
-      for (final settings in validSettings) {
-        final textFile = settings['text_file'] as String;
-        final setSettings = settings['set_settings'] as Map<String, num>;
-        await AppSettings.initialize(
-          readOnly: JsonMap.fromTextFile(
-            FakeTextFile(textFile),
-          ),
+  final validReadOnlyMaps = [
+    {
+      'test_setting_1': 0,
+      'test_setting_2': 27,
+      'test_setting_3': -123,
+    }, // int
+    {
+      'test_setting_1': 0.0,
+      'test_setting_2': 27.0,
+      'test_setting_3': -123.0,
+    }, // double
+    {
+      'test_setting_1': '0',
+      'test_setting_2': '27',
+      'test_setting_3': '-123',
+    }, // string
+    {
+      'test_setting_1': true,
+      'test_setting_2': false,
+      'test_setting_3': true,
+    }, // bool
+  ];
+  final validWritableMaps = [
+    {
+      'test_writable_setting_1': 0,
+      'test_writable_setting_2': 27,
+      'test_writable_setting_3': -123,
+    }, // int
+    {
+      'test_writable_setting_1': 0.0,
+      'test_writable_setting_2': 27.0,
+      'test_writable_setting_3': -123.0,
+    }, // double
+    {
+      'test_writable_setting_1': '0',
+      'test_writable_setting_2': '27',
+      'test_writable_setting_3': '-123',
+    }, // string
+    {
+      'test_writable_setting_1': true,
+      'test_writable_setting_2': false,
+      'test_writable_setting_3': true,
+    }, // bool
+  ];
+  group('AppSettings initialize', () {
+    test('sets data normally with valid readOnly json map', () async {
+      //
+      for (final map in validReadOnlyMaps) {
+        await AppSettings.initialize(readOnly: FakeJsonMap(Ok(map)));
+        expect(
+          AppSettings.getSetting('test_setting_1', onError: ((err) => null)),
+          map['test_setting_1'],
         );
-        expect(AppSettings.getSetting('test_setting_1', onError: ((err) => null)), setSettings['test_setting_1']);
-        expect(AppSettings.getSetting('test_setting_2', onError: ((err) => null)), setSettings['test_setting_2']);
-        expect(AppSettings.getSetting('test_setting_3', onError: ((err) => null)), setSettings['test_setting_3']);
-        expect(AppSettings.getSetting('1234', onError: ((err) => 1234)), 1234);
+        expect(
+          AppSettings.getSetting('test_setting_2', onError: ((err) => null)),
+          map['test_setting_2'],
+        );
+        expect(
+          AppSettings.getSetting('test_setting_3', onError: ((err) => null)),
+          map['test_setting_3'],
+        );
       }
     });
-    // test('throws with valid json format and invalid data', () async {
-    //   for (final settings in invalidSettings) {
-    //     final textFile = settings['text_file'] as String;
-    //     expect(
-    //       () => AppSettings.initialize(
-    //         jsonMap: JsonMap.fromTextFile(
-    //           FakeTextFile(textFile),
-    //         ),
-    //       ),
-    //       throwsA(isA<TypeError>()),
-    //     );
-    //   }
-    // });
-    test('does not throw with invalid json format', () {
-      for (final invalidJson in invalidJsons) {
-        final textFile = invalidJson['text_file'] as String;
-        expectLater(AppSettings.initialize(
-            readOnly: JsonMap.fromTextFile(
-              FakeTextFile(textFile),
-            ),
-          ),
-          completes,
+    test('sets data normally with valid writable json map', () async {
+      for (final map in validWritableMaps) {
+        await AppSettings.initialize(writable: FakeJsonMap(Ok(map)));
+        expect(
+          AppSettings.getSetting('test_writable_setting_1', onError: ((err) => null)),
+          map['test_writable_setting_1'],
+        );
+        expect(
+          AppSettings.getSetting('test_writable_setting_2', onError: ((err) => null)),
+          map['test_writable_setting_2'],
+        );
+        expect(
+          AppSettings.getSetting('test_writable_setting_3', onError: ((err) => null)),
+          map['test_writable_setting_3'],
         );
       }
+    });
+    test('writable settings overwrite readOnly settings', () async {
+      await AppSettings.initialize(
+        readOnly: const FakeJsonMap(Ok({
+          'test_overwrite_setting_1': 0,
+          'test_overwrite_setting_2': 27,
+          'test_overwrite_setting_3': -123,
+        })),
+        writable: const FakeJsonMap(Ok({
+          'test_overwrite_setting_1': -123,
+          'test_overwrite_setting_2': 0,
+          'test_overwrite_setting_3': 27,
+        })),
+      );
+      expect(AppSettings.getSetting('test_overwrite_setting_1'), -123);
+      expect(AppSettings.getSetting('test_overwrite_setting_2'), 0);
+      expect(AppSettings.getSetting('test_overwrite_setting_3'), 27);
+    });
+    test('getSetting onError passes new value case error', () async {
+      final notFoundMaps = [
+        {
+          'key': 'not_found_1',
+          'map_value': 0,
+        }, // int
+        {
+          'key': 'not_found_2',
+          'map_value': 0.0,
+        }, // int
+        {
+          'key': 'not_found_3',
+          'map_value': false,
+        }, // bool
+        {
+          'key': 'not_found_4',
+          'map_value': '0',
+        }, // string
+        {
+          'key': 'not_found_5',
+          'map_value': null,
+        }, // null
+      ];
+      for (final map in notFoundMaps) {
+        await AppSettings.initialize();
+        final key = map['key'] as String;
+        final mapValue = map['map_value'] as dynamic;
+        expect(
+          AppSettings.getSetting(key, onError: ((err) => mapValue)),
+          mapValue,
+        );
+      }
+    });
+    test('does not throw error with invalid json map', () async {
+      final mapWithError = FakeJsonMap(
+        Err(Failure(
+          message: 'invalid json map',
+          stackTrace: StackTrace.current,
+        )),
+      );
+      await expectLater(
+        AppSettings.initialize(readOnly: mapWithError),
+        completes,
+      );
+      await expectLater(
+        AppSettings.initialize(writable: mapWithError),
+        completes,
+      );
+      await expectLater(
+        AppSettings.initialize(readOnly: mapWithError, writable: mapWithError),
+        completes,
+      );
     });
   });
 }

--- a/test/unit/core/entities/app_settings/setting_test.dart
+++ b/test/unit/core/entities/app_settings/setting_test.dart
@@ -1,112 +1,217 @@
 import 'package:flutter_test/flutter_test.dart';
-import 'package:hmi_core/hmi_core.dart';
 import 'package:hmi_core/hmi_core_app_settings.dart';
-import 'fake_text_file.dart';
-import 'settings_data.dart';
+import 'package:hmi_core/src/core/error/failure.dart';
+import 'package:hmi_core/src/core/json/json_map.dart';
+import 'package:hmi_core/src/core/log/log.dart';
+import 'package:hmi_core/src/core/result/result.dart';
+///
+/// Fake implementation of [JsonMap] for tests
+class FakeJsonMap implements JsonMap<dynamic> {
+  final ResultF<Map<String, dynamic>> _map;
+  ///
+  /// Creates [FakeJsonMap] with a given [map].
+  const FakeJsonMap(ResultF<Map<String, dynamic>> map) : _map = map;
+  //
+  @override
+  Future<ResultF<Map<String, dynamic>>> get decoded async {
+    return _map;
+  }
+}
+//
 void main() {
+  final List<Map<String, dynamic>> validReadOnlyMaps = [
+    {
+      'test_setting_1': 0,
+      'test_setting_2': 27,
+      'test_setting_3': -123,
+    }, // int
+    {
+      'test_setting_1': 0.0,
+      'test_setting_2': 27.0,
+      'test_setting_3': -123.0,
+    }, // double
+  ];
+  final List<Map<String, dynamic>> validWritableMaps = [
+    {
+      'test_writable_setting_1': 0,
+      'test_writable_setting_2': 27,
+      'test_writable_setting_3': -123,
+    }, // int
+    {
+      'test_writable_setting_1': 0.0,
+      'test_writable_setting_2': 27.0,
+      'test_writable_setting_3': -123.0,
+    }, // double
+  ];
   group('Setting', () {
-    Log.initialize(level: LogLevel.all);
+    Log.initialize();
     const log = Log('Setting');
-    test('valid data', () async {
-      for (final settings in validSettings) {
-        final textFile = settings['text_file'] as String;
-        final setSettings = settings['set_settings'] as Map<String, num>;
-        await AppSettings.initialize(
-          readOnly: JsonMap.fromTextFile(
-            FakeTextFile(textFile),
-          ),
-        );
-        for (final setting in setSettings.entries) {
+    test('valid read only data', () async {
+      for (final settings in validReadOnlyMaps) {
+        await AppSettings.initialize(readOnly: FakeJsonMap(Ok(settings)));
+        for (final setting in settings.entries) {
           final int testSetting = Setting(setting.key).toInt;
           log.debug('as Int | ${setting.key}: $testSetting');
         }
-        for (final setting in setSettings.entries) {
+        for (final setting in settings.entries) {
           final double testSetting = Setting(setting.key).toDouble;
           log.debug('as Double | ${setting.key}: $testSetting');
         }
-        for (final setting in setSettings.entries) {
+        for (final setting in settings.entries) {
           final String testSetting = Setting(setting.key).toString();
           log.debug('as String | ${setting.key}: $testSetting');
         }
-        expect(const Setting('test_setting_1').toInt, setSettings['test_setting_1']!.toInt());
-        expect(const Setting('test_setting_2').toInt, setSettings['test_setting_2']!.toInt());
-        expect(const Setting('test_setting_3').toInt, setSettings['test_setting_3']!.toInt());
-        expect(const Setting('test_setting_1').toDouble, setSettings['test_setting_1']!.toDouble());
-        expect(const Setting('test_setting_2').toDouble, setSettings['test_setting_2']!.toDouble());
-        expect(const Setting('test_setting_3').toDouble, setSettings['test_setting_3']!.toDouble());
-        expect(const Setting('test_setting_1').toString(), setSettings['test_setting_1']!.toString());
-        expect(const Setting('test_setting_2').toString(), setSettings['test_setting_2']!.toString());
-        expect(const Setting('test_setting_3').toString(), setSettings['test_setting_3']!.toString());
+        expect(const Setting('test_setting_1').toInt, settings['test_setting_1']!.toInt());
+        expect(const Setting('test_setting_2').toInt, settings['test_setting_2']!.toInt());
+        expect(const Setting('test_setting_3').toInt, settings['test_setting_3']!.toInt());
+        expect(const Setting('test_setting_1').toDouble, settings['test_setting_1']!.toDouble());
+        expect(const Setting('test_setting_2').toDouble, settings['test_setting_2']!.toDouble());
+        expect(const Setting('test_setting_3').toDouble, settings['test_setting_3']!.toDouble());
+        expect(const Setting('test_setting_1').toString(), settings['test_setting_1']!.toString());
+        expect(const Setting('test_setting_2').toString(), settings['test_setting_2']!.toString());
+        expect(const Setting('test_setting_3').toString(), settings['test_setting_3']!.toString());
       }
     });
-    test('key not found', () async {
-      for (final settings in validSettings) {
-        final textFile = settings['text_file'] as String;
-        final setSettings = settings['set_settings'] as Map<String, num>;
-        await AppSettings.initialize(
-          readOnly: JsonMap.fromTextFile(
-            FakeTextFile(textFile),
-          ),
-        );
-        for (final setting in setSettings.entries) {
+    test('valid writable data', () async {
+      for (final settings in validWritableMaps) {
+        await AppSettings.initialize(writable: FakeJsonMap(Ok(settings)));
+        for (final setting in settings.entries) {
           final int testSetting = Setting(setting.key).toInt;
           log.debug('as Int | ${setting.key}: $testSetting');
         }
-        for (final setting in setSettings.entries) {
+        for (final setting in settings.entries) {
           final double testSetting = Setting(setting.key).toDouble;
           log.debug('as Double | ${setting.key}: $testSetting');
         }
-        for (final setting in setSettings.entries) {
+        for (final setting in settings.entries) {
           final String testSetting = Setting(setting.key).toString();
           log.debug('as String | ${setting.key}: $testSetting');
         }
-        expect(Setting('test_setting_1111', onError: (err) => 111,).toInt, 111);
-        expect(Setting('test_setting_1222', onError: (err) => -222,).toInt, -222);
-        expect(Setting('test_setting_1.10', onError: (err) => 1.10,).toDouble, 1.10);
-        expect(Setting('test_setting_2.22', onError: (err) => 2.22,).toDouble, 2.22);
+        expect(const Setting('test_writable_setting_1').toInt, settings['test_writable_setting_1']!.toInt());
+        expect(const Setting('test_writable_setting_2').toInt, settings['test_writable_setting_2']!.toInt());
+        expect(const Setting('test_writable_setting_3').toInt, settings['test_writable_setting_3']!.toInt());
+        expect(const Setting('test_writable_setting_1').toDouble, settings['test_writable_setting_1']!.toDouble());
+        expect(const Setting('test_writable_setting_2').toDouble, settings['test_writable_setting_2']!.toDouble());
+        expect(const Setting('test_writable_setting_3').toDouble, settings['test_writable_setting_3']!.toDouble());
+        expect(const Setting('test_writable_setting_1').toString(), settings['test_writable_setting_1']!.toString());
+        expect(const Setting('test_writable_setting_2').toString(), settings['test_writable_setting_2']!.toString());
+        expect(const Setting('test_writable_setting_3').toString(), settings['test_writable_setting_3']!.toString());
+      }
+    });
+    test('read-only key not found', () async {
+      for (final settings in validReadOnlyMaps) {
+        await AppSettings.initialize(readOnly: FakeJsonMap(Ok(settings)));
+        for (final setting in settings.entries) {
+          final int testSetting = Setting(setting.key).toInt;
+          log.debug('as Int | ${setting.key}: $testSetting');
+        }
+        for (final setting in settings.entries) {
+          final double testSetting = Setting(setting.key).toDouble;
+          log.debug('as Double | ${setting.key}: $testSetting');
+        }
+        for (final setting in settings.entries) {
+          final String testSetting = Setting(setting.key).toString();
+          log.debug('as String | ${setting.key}: $testSetting');
+        }
+        expect(Setting('test_setting_1111', onError: (err) => 111).toInt, 111);
+        expect(Setting('test_setting_1222', onError: (err) => -222).toInt, -222);
+        expect(Setting('test_setting_1.10', onError: (err) => 1.10).toDouble, 1.10);
+        expect(Setting('test_setting_2.22', onError: (err) => 2.22).toDouble, 2.22);
         expect(Setting('test_setting_1234', onError: (err) => '1234').toString(), '1234');
         expect(Setting('test_setting_2345', onError: (err) => '2345').toString(), '2345');
       }
     });
-    test('valid data with factor', () async {
+    test('writable key not found', () async {
+      for (final settings in validWritableMaps) {
+        await AppSettings.initialize(writable: FakeJsonMap(Ok(settings)));
+        for (final setting in settings.entries) {
+          final int testSetting = Setting(setting.key).toInt;
+          log.debug('as Int | ${setting.key}: $testSetting');
+        }
+        for (final setting in settings.entries) {
+          final double testSetting = Setting(setting.key).toDouble;
+          log.debug('as Double | ${setting.key}: $testSetting');
+        }
+        for (final setting in settings.entries) {
+          final String testSetting = Setting(setting.key).toString();
+          log.debug('as String | ${setting.key}: $testSetting');
+        }
+        expect(Setting('test_writable_setting_1111', onError: (err) => 111).toInt, 111);
+        expect(Setting('test_writable_setting_1222', onError: (err) => -222).toInt, -222);
+        expect(Setting('test_writable_setting_1.10', onError: (err) => 1.10).toDouble, 1.10);
+        expect(Setting('test_writable_setting_2.22', onError: (err) => 2.22).toDouble, 2.22);
+        expect(Setting('test_writable_setting_1234', onError: (err) => '1234').toString(), '1234');
+        expect(Setting('test_writable_setting_2345', onError: (err) => '2345').toString(), '2345');
+      }
+    });
+    test('valid read-only data with factor', () async {
       const factors = [0.123, -0.123, 3.54, -5.12];
       for (final factor in factors) {
-        for (final settings in validSettings) {
-          final textFile = settings['text_file'] as String;
-          final setSettings = settings['set_settings'] as Map<String, num>;
-          await AppSettings.initialize(
-            readOnly: JsonMap.fromTextFile(
-              FakeTextFile(textFile),
-            ),
-          );
-          for (final setting in setSettings.entries) {
+        for (final settings in validReadOnlyMaps) {
+          await AppSettings.initialize(readOnly: FakeJsonMap(Ok(settings)));
+          for (final setting in settings.entries) {
             final int testSetting = Setting(setting.key, factor: factor).toInt;
             log.debug('as Int | ${setting.key} * $factor: $testSetting');
           }
-          for (final setting in setSettings.entries) {
+          for (final setting in settings.entries) {
             final double testSetting = Setting(setting.key, factor: factor).toDouble;
             log.debug('as Double | ${setting.key} * $factor: $testSetting');
           }
           const factorConst = 0.123;
           const setting = Setting('test_setting_1', factor: factorConst);
-          expect(setting.toInt, (setSettings['test_setting_1']! * factor).toInt());
-          expect(Setting('test_setting_1', factor: factor).toInt, (setSettings['test_setting_1']! * factor).toInt());
-          expect(Setting('test_setting_2', factor: factor).toInt, (setSettings['test_setting_2']! * factor).toInt());
-          expect(Setting('test_setting_3', factor: factor).toInt, (setSettings['test_setting_3']! * factor).toInt());
-          expect(Setting('test_setting_1', factor: factor).toDouble, (setSettings['test_setting_1']! * factor).toDouble());
-          expect(Setting('test_setting_2', factor: factor).toDouble, (setSettings['test_setting_2']! * factor).toDouble());
-          expect(Setting('test_setting_3', factor: factor).toDouble, (setSettings['test_setting_3']! * factor).toDouble());
+          expect(setting.toInt, (settings['test_setting_1']! * factor).toInt());
+          expect(Setting('test_setting_1', factor: factor).toInt, (settings['test_setting_1']! * factor).toInt());
+          expect(Setting('test_setting_2', factor: factor).toInt, (settings['test_setting_2']! * factor).toInt());
+          expect(Setting('test_setting_3', factor: factor).toInt, (settings['test_setting_3']! * factor).toInt());
+          expect(Setting('test_setting_1', factor: factor).toDouble, (settings['test_setting_1']! * factor).toDouble());
+          expect(Setting('test_setting_2', factor: factor).toDouble, (settings['test_setting_2']! * factor).toDouble());
+          expect(Setting('test_setting_3', factor: factor).toDouble, (settings['test_setting_3']! * factor).toDouble());
         }
       }
     });
-    test('does not throw with invalid json', () {
-      for (final invalidJson in invalidJsons) {
-        final textFile = invalidJson['text_file'] as String;
-        expectLater(AppSettings.initialize(
-            readOnly: JsonMap.fromTextFile(
-              FakeTextFile(textFile),
-            ),
-          ),
+    test('valid writable data with factor', () async {
+      const factors = [0.123, -0.123, 3.54, -5.12];
+      for (final factor in factors) {
+        for (final settings in validWritableMaps) {
+          await AppSettings.initialize(writable: FakeJsonMap(Ok(settings)));
+          for (final setting in settings.entries) {
+            final int testSetting = Setting(setting.key, factor: factor).toInt;
+            log.debug('as Int | ${setting.key} * $factor: $testSetting');
+          }
+          for (final setting in settings.entries) {
+            final double testSetting = Setting(setting.key, factor: factor).toDouble;
+            log.debug('as Double | ${setting.key} * $factor: $testSetting');
+          }
+          const factorConst = 0.123;
+          const setting = Setting('test_writable_setting_1', factor: factorConst);
+          expect(setting.toInt, (settings['test_writable_setting_1']! * factor).toInt());
+          expect(Setting('test_writable_setting_1', factor: factor).toInt, (settings['test_writable_setting_1']! * factor).toInt());
+          expect(Setting('test_writable_setting_2', factor: factor).toInt, (settings['test_writable_setting_2']! * factor).toInt());
+          expect(Setting('test_writable_setting_3', factor: factor).toInt, (settings['test_writable_setting_3']! * factor).toInt());
+          expect(Setting('test_writable_setting_1', factor: factor).toDouble, (settings['test_writable_setting_1']! * factor).toDouble());
+          expect(Setting('test_writable_setting_2', factor: factor).toDouble, (settings['test_writable_setting_2']! * factor).toDouble());
+          expect(Setting('test_writable_setting_3', factor: factor).toDouble, (settings['test_writable_setting_3']! * factor).toDouble());
+        }
+      }
+    });
+    test('does not throw with invalid map', () {
+      final invalidJsonMaps = [
+        FakeJsonMap(Err(Failure(
+          message: 'error',
+          stackTrace: StackTrace.current,
+        ))),
+        FakeJsonMap(Err(Failure(
+          message: null,
+          stackTrace: StackTrace.current,
+        ))),
+        FakeJsonMap(Err(Failure(
+          message: '{"validJson":true}',
+          stackTrace: StackTrace.current,
+        ))),
+      ];
+      for (final invalidJsonMap in invalidJsonMaps) {
+        expectLater(
+          AppSettings.initialize(readOnly: invalidJsonMap),
           completes,
         );
       }


### PR DESCRIPTION
Is it correct that we test initialization of AppSettings using a FakeTextFile and not create fake of JsonMap?

I think that FakeJsonMap should be used because AppSettings doesn't really know where the maps that were passed to the initialize method came from.

This should make both the tests themselves (no need to test every edge case that might occur in JsonMap, it is already tested in tests for this class) and their understanding easier.